### PR TITLE
update Node.js version prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is a [Node.js](https://nodejs.org/en/) module available through the
 [npm registry](https://www.npmjs.com/).
 -->
 
-Before installing, [download and install Node.js](https://developer.ibm.com/node/sdk/ztp/).
-Node.js 8.16 for z/OS or higher is required.
+Before installing, [download and install IBM Open Enterprise SDK for Node.js](https://www.ibm.com/docs/en/sdk-nodejs-zos)
+16 or higher. zrexx v1.0.8 or higher is required for Node.js 18 or higher.
 
 ## Simple to use
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zrexx",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Call z/OS PDS REXX scripts from node-js",
   "main": "index.js",
   "gypfile": true,


### PR DESCRIPTION
Also update the no-longer-valid link to the Node.js versions.